### PR TITLE
feat(middleware): add middleware with provider to handle workspace_id in all requests

### DIFF
--- a/src/api/middlewares/__init__.py
+++ b/src/api/middlewares/__init__.py
@@ -4,6 +4,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from .logging import logging_middleware
 from .update_tokens import update_tokens_middleware
+from .workspace import WorkspaceMiddleware
 
 
 def init_middlewares(app: FastAPI) -> None:
@@ -16,6 +17,7 @@ def init_middlewares(app: FastAPI) -> None:
         BaseHTTPMiddleware,
         dispatch=update_tokens_middleware,
     )
+    app.add_middleware(WorkspaceMiddleware)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=['*'],

--- a/src/api/middlewares/workspace.py
+++ b/src/api/middlewares/workspace.py
@@ -13,6 +13,9 @@ class WorkspaceMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
         workspace_id = self._get_workspace_id_from_headers(request)
 
+        if request.url.path in ['/', '/openapi.json']: # временно !
+            return await call_next(request)
+
         if workspace_id is None:
             raise HTTPException(status_code=400, detail="Workspace ID is missing in request headers")
 

--- a/src/api/middlewares/workspace.py
+++ b/src/api/middlewares/workspace.py
@@ -1,0 +1,34 @@
+from typing import Awaitable, Callable
+from uuid import UUID
+
+from fastapi import HTTPException, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class WorkspaceMiddleware(BaseHTTPMiddleware):
+    """
+    Этот middleware необходим для работы с несколькими рабочими пространствами в рамках одного пользователя.
+    Его задача — удостовериться, что данные каждого запроса связаны с правильным рабочим пространством.
+    """
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        workspace_id = self._get_workspace_id_from_headers(request)
+
+        if workspace_id is None:
+            raise HTTPException(status_code=400, detail="Workspace ID is missing in request headers")
+
+        request.state.workspace_id = workspace_id
+        response = await call_next(request)
+
+        return response
+
+    @staticmethod
+    def _get_workspace_id_from_headers(request: Request) -> UUID | None:
+        workspace_id_str = request.headers.get("X-Workspace-Id")
+
+        if workspace_id_str:
+            try:
+                return UUID(workspace_id_str)
+            except ValueError:
+                raise HTTPException(status_code=400, detail="Invalid Workspace ID format")
+
+        return None

--- a/src/api/middlewares/workspace.py
+++ b/src/api/middlewares/workspace.py
@@ -2,6 +2,7 @@ from typing import Awaitable, Callable
 from uuid import UUID
 
 from fastapi import HTTPException, Request, Response
+from fastapi.routing import APIRoute, Match
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
@@ -11,23 +12,33 @@ class WorkspaceMiddleware(BaseHTTPMiddleware):
     Его задача — удостовериться, что данные каждого запроса связаны с правильным рабочим пространством.
     """
     async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
-        workspace_id = self._get_workspace_id_from_headers(request)
-
-        if request.url.path in ['/', '/openapi.json']: # временно !
+        if  self._is_excluded_route(request):
             return await call_next(request)
 
+        workspace_id = self._get_workspace_id_from_headers(request)
         if workspace_id is None:
             raise HTTPException(status_code=400, detail="Workspace ID is missing in request headers")
 
         request.state.workspace_id = workspace_id
-        response = await call_next(request)
 
-        return response
+        return await call_next(request)
+
+    @staticmethod
+    def _is_excluded_route(request: Request) -> bool:
+        if request.url.path in ['/', '/openapi.json']:
+            return True
+
+        for route in request.app.routes:
+            if isinstance(route, APIRoute):
+                match, _ = route.matches(request.scope)
+                if match == Match.FULL:
+                    return 'Users' in route.tags
+
+        return False
 
     @staticmethod
     def _get_workspace_id_from_headers(request: Request) -> UUID | None:
         workspace_id_str = request.headers.get("X-Workspace-Id")
-
         if workspace_id_str:
             try:
                 return UUID(workspace_id_str)

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from src.providers.adapters import (
     ConfigProvider,
     RepositoriesProvider,
     SqlalchemyProvider,
+    WorkspaceProvider,
 )
 from src.providers.usecases import (
     CategoryUseCaseProvider,
@@ -42,6 +43,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 def container_factory() -> AsyncContainer:
     return make_async_container(
         SqlalchemyProvider(),
+        WorkspaceProvider(),
         ConfigProvider(),
         RepositoriesProvider(),
         ProjectInteractorProvider(),

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ import uvicorn
 from dishka import AsyncContainer, make_async_container
 from dishka.integrations.fastapi import setup_dishka
 from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
 
 from src.api import init_exception_handlers, init_routes
 from src.api.middlewares import init_middlewares
@@ -82,6 +83,32 @@ async def start_server(app: FastAPI) -> None:
     await server.serve()
 
 
+def customize_openapi(app: FastAPI):
+    """
+    Настраивает OpenAPI схему для добавления заголовка X-Workspace-Id.
+    """
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description,
+        routes=app.routes,
+    )
+    openapi_schema["components"]["securitySchemes"] = {
+        "WorkspaceHeader": {
+            "type": "apiKey",
+            "name": "X-Workspace-Id",
+            "in": "header",
+        }
+    }
+    openapi_schema["security"] = [{"WorkspaceHeader": []}]
+
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
 def create_app() -> FastAPI:
     app = FastAPI(
         title='Sup API',
@@ -90,6 +117,8 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
         docs_url='/',
     )
+    app.openapi = lambda: customize_openapi(app)
+
     init_services(app)
     init_di(app)
     init_routes(app)

--- a/src/providers/context.py
+++ b/src/providers/context.py
@@ -1,0 +1,6 @@
+from uuid import UUID
+
+
+class WorkspaceContext:
+    def __init__(self, workspace_id: UUID):
+        self.workspace_id = workspace_id


### PR DESCRIPTION
Я добавил middleware, теперь если в заголовке передается X-Workspace_Id то все данные будут для этого воркспейс, можно убрать workspace_id из ручек и интеракторов, и просто делать вот так где нужны данные связынные с воркспейсом(везде)):

```python
class EntityRepository(IEntityRepository):
    def __init__(self, session: AsyncSession, context: WorkspaceContext):
        self._session = session
        self._context = context
        
   def get_projects(self):
       query = select(ProjectModel).filter_by(workspace_id=self.context.workspace_id)
       result = session.execute(query)
       return result
    
```

Главное контекст на фронте будет настроить, чтоб там при смене воркспейса, подставлялся его id в заголовок.

Сразу поясню, это не то что просила Лена(

Это нужно для:

1.  Того чтоб не передавать в каждую ручку, workspace_id, а из ручки не передавать в интерактор, а из интерактора в репозиторий. То есть мы просто прокидываем зависимость от контекста воркспейса в атрибут репозитория и используем в нужом методе репозитория. Как по мне, удобно, тем более что у нас абсолютно все зависит от конкретного воркспейса)
2. Если пользователь будет менять воркспейс, он его меняет, фронтенд  отправляет запрос на смену воркспейса, сервер возвращает воркспейс, фронт записывает в заголовок, нужный воркспейс и все, теперь у нас в контексте тот воркспейс на который мы переключились, и все запросы будут идти с правильным workspace_id для каждого запроса.

Чтоб тестить в доке, так как у нас нет пока фронта, нужно передать workspace_id вот сюда:

![1](https://github.com/user-attachments/assets/21e56528-f71c-4eca-8c3f-20f397f360e4)
![2](https://github.com/user-attachments/assets/83c88b23-3de6-4b15-a7e6-6ad1a81e6a97)

